### PR TITLE
Persistent sessions

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
+	flagSet.String("oidc-audience", "", "OpenID Connect audience params")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 	flagSet.Bool("pass-user-headers", true, "pass X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
+	flagSet.Bool("pass-id-token", false, "pass OpenID Connect id_token to upstream via X-Forwarded-ID-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	b64 "encoding/base64"
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"html/template"
@@ -16,7 +17,9 @@ import (
 
 	"github.com/bitly/oauth2_proxy/cookie"
 	"github.com/bitly/oauth2_proxy/providers"
+	"github.com/gorilla/securecookie"
 	"github.com/mbland/hmacauth"
+	"github.com/quasoft/memstore"
 )
 
 const SignatureHeader = "GAP-Signature"
@@ -72,6 +75,7 @@ type OAuthProxy struct {
 	compiledRegex       []*regexp.Regexp
 	templates           *template.Template
 	Footer              string
+	SessionStore        *memstore.MemStore
 }
 
 type UpstreamProxy struct {
@@ -117,6 +121,7 @@ func NewFileServer(path string, filesystemPath string) (proxy http.Handler) {
 
 func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	serveMux := http.NewServeMux()
+
 	var auth hmacauth.HmacAuth
 	if sigData := opts.signatureData; sigData != nil {
 		auth = hmacauth.NewHmacAuth(sigData.hash, []byte(sigData.key),
@@ -162,14 +167,14 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 
 	log.Printf("Cookie settings: name:%s secure(https):%v httponly:%v expiry:%s domain:%s refresh:%s", opts.CookieName, opts.CookieSecure, opts.CookieHttpOnly, opts.CookieExpire, opts.CookieDomain, refresh)
 
-	var cipher *cookie.Cipher
-	if opts.PassAccessToken || (opts.CookieRefresh != time.Duration(0)) {
-		var err error
-		cipher, err = cookie.NewCipher(secretBytes(opts.CookieSecret))
-		if err != nil {
-			log.Fatal("cookie-secret error: ", err)
-		}
-	}
+	// using random keys here means we lose sessions on restart
+	var store = memstore.NewMemStore(
+		[]byte(securecookie.GenerateRandomKey(32)),
+		[]byte(securecookie.GenerateRandomKey(32)),
+	)
+
+	// needed to encode expiration time into the session
+	gob.Register(time.Time{})
 
 	return &OAuthProxy{
 		CookieName:     opts.CookieName,
@@ -203,10 +208,9 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		BasicAuthPassword:  opts.BasicAuthPassword,
 		PassAccessToken:    opts.PassAccessToken,
 		SkipProviderButton: opts.SkipProviderButton,
-		CookieCipher:       cipher,
 		templates:          loadTemplates(opts.CustomTemplatesDir),
 		Footer:             opts.Footer,
-	}
+		SessionStore:       store}
 }
 
 func (p *OAuthProxy) GetRedirectURI(host string) string {
@@ -311,37 +315,75 @@ func (p *OAuthProxy) ClearSessionCookie(rw http.ResponseWriter, req *http.Reques
 	}
 }
 
+func (p *OAuthProxy) SetPersistentSessionCookie(rw http.ResponseWriter, req *http.Request, s *providers.SessionState) {
+	// Get a session. Get() always returns a session, even if empty.
+	session, err := p.SessionStore.Get(req, p.CookieName)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	session.Values["AccessToken"] = s.AccessToken
+	session.Values["ExpiresOn"] = s.ExpiresOn
+	session.Values["RefreshToken"] = s.RefreshToken
+	session.Values["Email"] = s.Email
+	session.Values["User"] = strings.Split(s.Email, "@")[0]
+	session.Values["IDToken"] = s.IDToken
+
+	fmt.Printf("Saving IDToken %s", s.IDToken)
+
+	fmt.Println("--- Saving session")
+	fmt.Println(session.Values["AccessToken"])
+	// Save it before we write to the response/return from the handler.
+	session.Save(req, rw)
+}
+
 func (p *OAuthProxy) SetSessionCookie(rw http.ResponseWriter, req *http.Request, val string) {
 	http.SetCookie(rw, p.MakeSessionCookie(req, val, p.CookieExpire, time.Now()))
 }
 
-func (p *OAuthProxy) LoadCookiedSession(req *http.Request) (*providers.SessionState, time.Duration, error) {
+func (p *OAuthProxy) LoadPersistedSession(req *http.Request) (*providers.SessionState, time.Duration, error) {
 	var age time.Duration
-	c, err := req.Cookie(p.CookieName)
+
+	session, err := p.SessionStore.Get(req, p.CookieName)
+
 	if err != nil {
-		// always http.ErrNoCookie
+		fmt.Printf("err")
+	}
+
+	if session.IsNew == true {
 		return nil, age, fmt.Errorf("Cookie %q not present", p.CookieName)
 	}
-	val, timestamp, ok := cookie.Validate(c, p.CookieSeed, p.CookieExpire)
+
+	email := session.Values["Email"].(string)
+	user := session.Values["User"].(string)
+
+	fmt.Printf("Persisted value email: %s", email)
+
+	ok := false
+
+	s := &providers.SessionState{User: user, Email: email}
+	s.AccessToken, ok = session.Values["AccessToken"].(string)
 	if !ok {
-		return nil, age, errors.New("Cookie Signature not valid")
+		// nothing
 	}
-
-	session, err := p.provider.SessionFromCookie(val, p.CookieCipher)
-	if err != nil {
-		return nil, age, err
+	s.RefreshToken, ok = session.Values["RefreshToken"].(string)
+	if !ok {
+		// nothing
 	}
+	s.IDToken, ok = session.Values["IDToken"].(string)
+	if !ok {
+		// nothing
+	}
+	fmt.Printf("Persisted accesstoken value: %s", s.AccessToken)
 
-	age = time.Now().Truncate(time.Second).Sub(timestamp)
-	return session, age, nil
+	return s, time.Now().Truncate(time.Second).Sub(time.Now()), nil
 }
 
 func (p *OAuthProxy) SaveSession(rw http.ResponseWriter, req *http.Request, s *providers.SessionState) error {
-	value, err := p.provider.CookieForSession(s, p.CookieCipher)
-	if err != nil {
-		return err
-	}
-	p.SetSessionCookie(rw, req, value)
+
+	fmt.Printf("session.email %s ", s.Email)
+	p.SetPersistentSessionCookie(rw, req, s) // this is the raw sessionstore object
 	return nil
 }
 
@@ -611,10 +653,15 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	var saveSession, clearSession, revalidated bool
 	remoteAddr := getRemoteAddr(req)
 
-	session, sessionAge, err := p.LoadCookiedSession(req)
+	session, sessionAge, err := p.LoadPersistedSession(req)
 	if err != nil {
 		log.Printf("%s %s", remoteAddr, err)
 	}
+
+	if session != nil {
+		fmt.Printf("Loaded Access Token %s", session.AccessToken)
+	}
+
 	if session != nil && sessionAge > p.CookieRefresh && p.CookieRefresh != time.Duration(0) {
 		log.Printf("%s refreshing %s old session cookie for %s (refresh after %s)", remoteAddr, sessionAge, session, p.CookieRefresh)
 		saveSession = true
@@ -683,12 +730,14 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 			req.Header["X-Forwarded-Email"] = []string{session.Email}
 		}
 	}
+
 	if p.PassUserHeaders {
 		req.Header["X-Forwarded-User"] = []string{session.User}
 		if session.Email != "" {
 			req.Header["X-Forwarded-Email"] = []string{session.Email}
 		}
 	}
+
 	if p.SetXAuthRequest {
 		rw.Header().Set("X-Auth-Request-User", session.User)
 		if session.Email != "" {
@@ -696,13 +745,17 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		}
 		if p.PassAccessToken && session.AccessToken != "" {
 			rw.Header().Set("X-Auth-Request-Access-Token", session.AccessToken)
-			rw.Header().Set("X-Auth-Request-ID-Token", session.IdToken)
+			// TODO: make this its own cmd line option
+			rw.Header().Set("X-Auth-Request-ID-Token", session.IDToken)
 		}
 	}
+
 	if p.PassAccessToken && session.AccessToken != "" {
 		req.Header["X-Forwarded-Access-Token"] = []string{session.AccessToken}
-		req.Header["X-Forwarded-ID-Token"] = []string{session.IdToken}
+		// TODO: make this its own cmd line option
+		req.Header["X-Forwarded-ID-Token"] = []string{session.IDToken}
 	}
+
 	if session.Email == "" {
 		rw.Header().Set("GAP-Auth", session.User)
 	} else {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -69,6 +69,7 @@ type OAuthProxy struct {
 	PassUserHeaders     bool
 	BasicAuthPassword   string
 	PassAccessToken     bool
+	PassIdToken         bool
 	CookieCipher        *cookie.Cipher
 	skipAuthRegex       []string
 	skipAuthPreflight   bool
@@ -207,6 +208,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		PassUserHeaders:    opts.PassUserHeaders,
 		BasicAuthPassword:  opts.BasicAuthPassword,
 		PassAccessToken:    opts.PassAccessToken,
+		PassIdToken:        opts.PassIdToken,
 		SkipProviderButton: opts.SkipProviderButton,
 		templates:          loadTemplates(opts.CustomTemplatesDir),
 		Footer:             opts.Footer,
@@ -745,14 +747,17 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		}
 		if p.PassAccessToken && session.AccessToken != "" {
 			rw.Header().Set("X-Auth-Request-Access-Token", session.AccessToken)
-			// TODO: make this its own cmd line option
+		}
+		if p.PassIdToken && session.IDToken != "" {
 			rw.Header().Set("X-Auth-Request-ID-Token", session.IDToken)
 		}
 	}
 
 	if p.PassAccessToken && session.AccessToken != "" {
 		req.Header["X-Forwarded-Access-Token"] = []string{session.AccessToken}
-		// TODO: make this its own cmd line option
+	}
+
+	if p.PassIdToken && session.IDToken != "" {
 		req.Header["X-Forwarded-ID-Token"] = []string{session.IDToken}
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -694,9 +694,14 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		if session.Email != "" {
 			rw.Header().Set("X-Auth-Request-Email", session.Email)
 		}
+		if p.PassAccessToken && session.AccessToken != "" {
+			rw.Header().Set("X-Auth-Request-Access-Token", session.AccessToken)
+			rw.Header().Set("X-Auth-Request-ID-Token", session.IdToken)
+		}
 	}
 	if p.PassAccessToken && session.AccessToken != "" {
 		req.Header["X-Forwarded-Access-Token"] = []string{session.AccessToken}
+		req.Header["X-Forwarded-ID-Token"] = []string{session.IdToken}
 	}
 	if session.Email == "" {
 		rw.Header().Set("GAP-Auth", session.User)

--- a/options.go
+++ b/options.go
@@ -55,6 +55,7 @@ type Options struct {
 	PassBasicAuth         bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
 	BasicAuthPassword     string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
 	PassAccessToken       bool     `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassIdToken           bool     `flag:"pass-id-token" cfg:"pass_id_token"`
 	PassHostHeader        bool     `flag:"pass-host-header" cfg:"pass_host_header"`
 	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
 	PassUserHeaders       bool     `flag:"pass-user-headers" cfg:"pass_user_headers"`
@@ -110,6 +111,7 @@ func NewOptions() *Options {
 		PassBasicAuth:        true,
 		PassUserHeaders:      true,
 		PassAccessToken:      false,
+		PassIdToken:          false,
 		PassHostHeader:       true,
 		ApprovalPrompt:       "force",
 		RequestLogging:       true,

--- a/options.go
+++ b/options.go
@@ -23,7 +23,7 @@ type Options struct {
 	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
 	HttpAddress  string `flag:"http-address" cfg:"http_address"`
 	HttpsAddress string `flag:"https-address" cfg:"https_address"`
-	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
+	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url" env:"OAUTH2_PROXY_REDIRECT_URL"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
 	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`

--- a/options.go
+++ b/options.go
@@ -66,6 +66,7 @@ type Options struct {
 	// potential overrides.
 	Provider          string `flag:"provider" cfg:"provider"`
 	OIDCIssuerURL     string `flag:"oidc-issuer-url" cfg:"oidc_issuer_url"`
+	OIDCAudience      string `flag:"oidc-audience" cfg:"oidc_audience"`
 	LoginURL          string `flag:"login-url" cfg:"login_url"`
 	RedeemURL         string `flag:"redeem-url" cfg:"redeem_url"`
 	ProfileURL        string `flag:"profile-url" cfg:"profile_url"`
@@ -256,6 +257,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	p.ProfileURL, msgs = parseURL(o.ProfileURL, "profile", msgs)
 	p.ValidateURL, msgs = parseURL(o.ValidateURL, "validate", msgs)
 	p.ProtectedResource, msgs = parseURL(o.ProtectedResource, "resource", msgs)
+	p.Audience = o.OIDCAudience
 
 	o.provider = providers.New(o.Provider, p)
 	switch p := o.provider.(type) {

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -29,9 +29,10 @@ func (p *OIDCProvider) Redeem(redirectURL, code string) (s *SessionState, err er
 		Endpoint: oauth2.Endpoint{
 			TokenURL: p.RedeemURL.String(),
 		},
-		RedirectURL: redirectURL,
-		Scopes: []string{"openid", "email", "profile"}}
+		RedirectURL: redirectURL}
+
 	token, err := c.Exchange(ctx, code)
+
 	if err != nil {
 		return nil, fmt.Errorf("token exchange: %v", err)
 	}
@@ -68,8 +69,10 @@ func (p *OIDCProvider) Redeem(redirectURL, code string) (s *SessionState, err er
 		RefreshToken: token.RefreshToken,
 		ExpiresOn:    token.Expiry,
 		Email:        claims.Email,
-		IdToken:			rawIDToken,
-	}
+		IDToken:      rawIDToken}
+
+	fmt.Println("Session state")
+	fmt.Println(s)
 
 	return
 }

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -30,7 +30,7 @@ func (p *OIDCProvider) Redeem(redirectURL, code string) (s *SessionState, err er
 			TokenURL: p.RedeemURL.String(),
 		},
 		RedirectURL: redirectURL,
-	}
+		Scopes: []string{"openid", "email", "profile"}}
 	token, err := c.Exchange(ctx, code)
 	if err != nil {
 		return nil, fmt.Errorf("token exchange: %v", err)
@@ -68,6 +68,7 @@ func (p *OIDCProvider) Redeem(redirectURL, code string) (s *SessionState, err er
 		RefreshToken: token.RefreshToken,
 		ExpiresOn:    token.Expiry,
 		Email:        claims.Email,
+		IdToken:			rawIDToken,
 	}
 
 	return

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -15,6 +15,7 @@ type ProviderData struct {
 	ValidateURL       *url.URL
 	Scope             string
 	ApprovalPrompt    string
+	Audience          string
 }
 
 func (p *ProviderData) Data() *ProviderData { return p }

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-
-	"github.com/bitly/oauth2_proxy/cookie"
 )
 
 func (p *ProviderData) Redeem(redirectURL, code string) (s *SessionState, err error) {
@@ -88,18 +86,9 @@ func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")
 	params.Add("state", state)
+	params.Add("audience", p.Audience)
 	a.RawQuery = params.Encode()
 	return a.String()
-}
-
-// CookieForSession serializes a session state for storage in a cookie
-func (p *ProviderData) CookieForSession(s *SessionState, c *cookie.Cipher) (string, error) {
-	return s.EncodeSessionState(c)
-}
-
-// SessionFromCookie deserializes a session from a cookie value
-func (p *ProviderData) SessionFromCookie(v string, c *cookie.Cipher) (s *SessionState, err error) {
-	return DecodeSessionState(v, c)
 }
 
 func (p *ProviderData) GetEmailAddress(s *SessionState) (string, error) {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -1,9 +1,5 @@
 package providers
 
-import (
-	"github.com/bitly/oauth2_proxy/cookie"
-)
-
 type Provider interface {
 	Data() *ProviderData
 	GetEmailAddress(*SessionState) (string, error)
@@ -13,8 +9,6 @@ type Provider interface {
 	ValidateSessionState(*SessionState) bool
 	GetLoginURL(redirectURI, finalRedirect string) string
 	RefreshSessionIfNeeded(*SessionState) (bool, error)
-	SessionFromCookie(string, *cookie.Cipher) (*SessionState, error)
-	CookieForSession(*SessionState, *cookie.Cipher) (string, error)
 }
 
 func New(provider string, p *ProviderData) Provider {

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -32,6 +32,9 @@ func (s *SessionState) String() string {
 	if s.RefreshToken != "" {
 		o += " refresh_token:true"
 	}
+	if s.IDToken != "" {
+		o += " id_token:true"
+	}
 	return o + "}"
 }
 

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -2,11 +2,7 @@ package providers
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
-
-	"github.com/bitly/oauth2_proxy/cookie"
 )
 
 type SessionState struct {
@@ -15,7 +11,7 @@ type SessionState struct {
 	RefreshToken string
 	Email        string
 	User         string
-	IdToken			 string
+	IDToken      string
 }
 
 func (s *SessionState) IsExpired() bool {
@@ -36,102 +32,9 @@ func (s *SessionState) String() string {
 	if s.RefreshToken != "" {
 		o += " refresh_token:true"
 	}
-	if s.IdToken != "" {
-		o += " id_token:true"
-	}
 	return o + "}"
-}
-
-func (s *SessionState) EncodeSessionState(c *cookie.Cipher) (string, error) {
-	if c == nil || s.AccessToken == "" {
-		return s.accountInfo(), nil
-	}
-	return s.EncryptedString(c)
 }
 
 func (s *SessionState) accountInfo() string {
 	return fmt.Sprintf("email:%s user:%s", s.Email, s.User)
-}
-
-func (s *SessionState) EncryptedString(c *cookie.Cipher) (string, error) {
-	var err error
-	if c == nil {
-		panic("error. missing cipher")
-	}
-	a := s.AccessToken
-	if a != "" {
-		if a, err = c.Encrypt(a); err != nil {
-			return "", err
-		}
-	}
-	r := s.RefreshToken
-	if r != "" {
-		if r, err = c.Encrypt(r); err != nil {
-			return "", err
-		}
-	}
-	idToken := s.IdToken
-	if idToken != "" {
-		idToken, err = c.Encrypt(idToken)
-		if err != nil {
-			return "", err
-		}
-	}
-	return fmt.Sprintf("%s|%s|%d|%s|%s", s.accountInfo(), a, s.ExpiresOn.Unix(), r, idToken), nil
-}
-
-func decodeSessionStatePlain(v string) (s *SessionState, err error) {
-	chunks := strings.Split(v, " ")
-	if len(chunks) != 2 {
-		return nil, fmt.Errorf("could not decode session state: expected 2 chunks got %d", len(chunks))
-	}
-
-	email := strings.TrimPrefix(chunks[0], "email:")
-	user := strings.TrimPrefix(chunks[1], "user:")
-	if user == "" {
-		user = strings.Split(email, "@")[0]
-	}
-
-	return &SessionState{User: user, Email: email}, nil
-}
-
-func DecodeSessionState(v string, c *cookie.Cipher) (s *SessionState, err error) {
-	if c == nil {
-		return decodeSessionStatePlain(v)
-	}
-
-	chunks := strings.Split(v, "|")
-	if len(chunks) != 5 {
-		err = fmt.Errorf("invalid number of fields (got %d expected 5)", len(chunks))
-		return
-	}
-
-	sessionState, err := decodeSessionStatePlain(chunks[0])
-	if err != nil {
-		return nil, err
-	}
-
-	if chunks[1] != "" {
-		if sessionState.AccessToken, err = c.Decrypt(chunks[1]); err != nil {
-			return nil, err
-		}
-	}
-
-	ts, _ := strconv.Atoi(chunks[2])
-	sessionState.ExpiresOn = time.Unix(int64(ts), 0)
-
-	if chunks[3] != "" {
-		if sessionState.RefreshToken, err = c.Decrypt(chunks[3]); err != nil {
-			return nil, err
-		}
-	}
-
-	if c != nil && chunks[4] != "" {
-		sessionState.IdToken, err = c.Decrypt(chunks[4])
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return sessionState, nil
 }


### PR DESCRIPTION
Originally, all session data was stored in the cookie itself. This presented a problem when we needed to store the `id_token` to use with [Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) (since the cookie grew beyond 4kb).

This PR changes the way sessions are stored. The cookie is simply a reference to the in-memory session record. We could optionally persist these in a database in the future if we wanted to.

I also added some new options to work with Phenix (`oidc-audience` and `pass-id-token`). 